### PR TITLE
build: install production group in build stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (C) 2025 Opal Health Informatics Group at the Research Institute of the McGill University Health Centre <john.kildea@mcgill.ca>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
+          lfs: true
+      - uses: opalmedapps/.github/.github/actions/docker-build@main
+        id: build-image
+        with:
+          registry: ${{ env.REGISTRY }}
+          image: ${{ env.IMAGE_NAME }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test the image
+        env:
+          TAG: ${{ steps.build-image.outputs.tag }}
+        run: docker run --rm "$TAG" sh -c "gunicorn --version && python manage.py check"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,5 @@ jobs:
       - name: Test the image
         env:
           TAG: ${{ steps.build-image.outputs.tag }}
-        run: docker run --rm "$TAG" sh -c "gunicorn --version && python manage.py check"
+        # ensure that gunicorn is installed and that simple checks pass
+        run: docker run --rm --env-file .env "$TAG" sh -c "gunicorn --version && python manage.py check"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,13 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # create minimal env file for testing the image
+      - name: Prepare environment
+        run: |
+          cp .env.sample .env
+          # generate secret key
+          SECRET_KEY=$(python -c "import secrets; print(secrets.token_urlsafe())")
+          sed -i "s/^SECRET_KEY=.*/SECRET_KEY=$SECRET_KEY/" .env
       - name: Test the image
         env:
           TAG: ${{ steps.build-image.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: gunicorn --help && python manage.py check
+      test-command: python manage.py check && gunicorn --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: python manage.py check && gunicorn --help
+      test-command: sh -c 'python manage.py check && gunicorn --help'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: /usr/local/bin/gunicorn --help
+      test-command: /usr/local/bin/gunicorn --help && python manage.py check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: sh -c 'python manage.py check && gunicorn --help'
+      test-command: sh -c "python manage.py check && gunicorn --help"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: "sh -c 'python manage.py check && gunicorn --help'"
+      test-command: "sh -c \"python manage.py check && gunicorn --help\""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: sh -c "python manage.py check && gunicorn --help"
+      test-command: "sh -c 'python manage.py check && gunicorn --help'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: python manage.py
+      test-command: /usr/local/bin/gunicorn --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: /usr/local/bin/gunicorn --help && python manage.py check
+      test-command: $(which gunicorn) --help && python manage.py check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,4 @@ jobs:
       packages: write
     uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
     with:
-      test-command: $(which gunicorn) --help && python manage.py check
+      test-command: gunicorn --help && python manage.py check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,13 +230,3 @@ jobs:
             mkdocs-material-
       - name: Build site
         run: uv run mkdocs build --strict
-
-  build-image:
-    needs:
-      - lint
-    permissions:
-      contents: read
-      packages: write
-    uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
-    with:
-      test-command: "sh -c \"python manage.py check && gunicorn --help\""

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,4 +83,4 @@ RUN cp .env.sample .env \
 USER appuser
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD [ "./start.sh" ]
+CMD [ "/app/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN apk add --no-cache build-base \
   # argon2-cffi dependencies
   && apk add --no-cache libffi-dev
 
-# for which environment the build is done: development or production
-ARG ENV=production
+# for which environment the build is done: dev or prod
+ARG ENV=prod
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-editable --no-dev --compile-bytecode
+    uv sync --locked --no-editable --no-default-groups --group $ENV --compile-bytecode
 
 
 FROM python:3.12.9-alpine3.20

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
       context: .
       args:
         # install development dependencies in the local image
-        - ENV=development
+        - ENV=dev
     command: python manage.py runserver 0:8000
     env_file:
       - .env

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -12,7 +12,7 @@ python /app/manage.py collectstatic --noinput
 
 # store temporary file in memory storage
 # https://pythonspeed.com/articles/gunicorn-in-docker/
-/usr/local/bin/gunicorn config.wsgi \
+gunicorn config.wsgi \
     --workers=4 \
     --worker-tmp-dir /dev/shm \
     --bind 0.0.0.0:8000  \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,6 @@ docs = [
     "mkdocs-material==9.6.11",
     "mkdocstrings[python-legacy]==0.27.0",
 ]
-production = [
+prod = [
     "gunicorn==23.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -74,7 +74,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python-legacy"] },
 ]
-production = [
+prod = [
     { name = "gunicorn" },
 ]
 
@@ -147,7 +147,7 @@ docs = [
     { name = "mkdocs-material", specifier = "==9.6.11" },
     { name = "mkdocstrings", extras = ["python-legacy"], specifier = "==0.27.0" },
 ]
-production = [{ name = "gunicorn", specifier = "==23.0.0" }]
+prod = [{ name = "gunicorn", specifier = "==23.0.0" }]
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
The built image in the registry is missing `gunicorn` indicating that the production dependencies are not installed.

Switch to docker-build action at the same time which makes it easier to test the image.