### PR TITLE
ci: reuse build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,7 @@
 name: build
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
-  merge_group:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,3 +230,11 @@ jobs:
             mkdocs-material-
       - name: Build site
         run: uv run mkdocs build --strict
+
+  build-image:
+    needs:
+      - lint
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,4 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: opalmedapps/.github/.github/workflows/docker-build.yaml@main
-    with:
-      test-command: python manage.py
+    uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Call `build` from `ci` after `lint` and also reuse `build` in `release` workflow.