### PR TITLE
fix: use correct fedauth authentication backend class name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,10 @@ jobs:
           # generate secret key
           SECRET_KEY=$(python -c "import secrets; print(secrets.token_urlsafe())")
           sed -i "s/^SECRET_KEY=.*/SECRET_KEY=$SECRET_KEY/" .env
+          # ensure that the fedauth auth backend is correct
+          FEDAUTH_API_ENDPOINT=https://example.com
+          sed -i "s/^FEDAUTH_API_ENDPOINT=.*/FEDAUTH_API_ENDPOINT=$FEDAUTH_API_ENDPOINT/" .env
+          sed -i "s/^FEDAUTH_INSTITUTION=.*/FEDAUTH_INSTITUTION=test/" .env
       - name: Test the image
         env:
           TAG: ${{ steps.build-image.outputs.tag }}


### PR DESCRIPTION
The authentication backend for fedauth is set conditionally.
The wrong class name was specified causing a startup error.