### PR TITLE
fix(data): ensure that legacy caregivers have the correct ID

### DIFF
--- a/opal/core/management/commands/insert_test_data.py
+++ b/opal/core/management/commands/insert_test_data.py
@@ -478,8 +478,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_rory,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),
-            start_date=_relative_date(today, -14),
+            request_date=today,
+            start_date=today,
         )
 
         # Cara --> Cara: Self
@@ -488,8 +488,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_cara,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Rory --> Cara: Family & Friends
@@ -498,8 +498,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_rory,
             relationship_type=type_family,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # John --> John: Self
@@ -508,8 +508,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_john,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),
-            start_date=_relative_date(today, -14),
+            request_date=today,
+            start_date=today,
         )
 
         # Richard --> Richard: Self
@@ -518,8 +518,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_richard,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # John --> Richard: Family & Friends
@@ -528,8 +528,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_john,
             relationship_type=type_family,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Mike --> Mike: Self
@@ -538,8 +538,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_mike,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Kathy --> Kathy: Self
@@ -548,8 +548,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_kathy,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Mike --> Kathy: Family & Friends
@@ -558,8 +558,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_mike,
             relationship_type=type_family,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Valerie --> Valerie: Self
@@ -568,8 +568,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_valerie,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Pete --> Pete: Self
@@ -578,8 +578,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_pete,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
         # Martin --> Martin: Self
@@ -588,8 +588,8 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             caregiver=user_martin,
             relationship_type=type_self,
             status=RelationshipStatus.CONFIRMED,
-            request_date=_relative_date(today, -14),  # TBC
-            start_date=_relative_date(today, -14),  # TBC
+            request_date=today,
+            start_date=today,
         )
 
     # The rest of the relationships exist at both institutions

--- a/opal/core/management/commands/insert_test_data.py
+++ b/opal/core/management/commands/insert_test_data.py
@@ -60,13 +60,13 @@ INSTITUTION_DATA = MappingProxyType({
         'name': 'Opal Demo',
         'name_fr': 'Démo de Opal',
         'acronym_fr': 'DO1',
-        'support_email': 'info@opalmedapps.ca',
+        'support_email': 'support@opalmedapps.ca',
     },
     InstitutionOption.ohigph: {
         'name': 'Opal Demo 2',
         'name_fr': 'Démo de Opal 2',
         'acronym_fr': 'DO2',
-        'support_email': 'info@opalmedapps.ca',
+        'support_email': 'support@opalmedapps.ca',
     },
 })
 
@@ -303,7 +303,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             last_name='Smith',
             date_of_birth=date(1985, 1, 1),
             sex=SexType.MALE,
-            ramq='',
+            ramq='ABCD99988877',
             legacy_id=93,
             mrns=mrn_data['John Smith'],
         )
@@ -372,7 +372,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='laurie@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=6,
+            legacy_id=1,
         )
         user_rory = _create_caregiver(
             first_name='Rory',
@@ -381,7 +381,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='rory@opalmedapps.ca',
             language='en',
             phone_number='+15145554321',
-            legacy_id=7,
+            legacy_id=2,
         )
         user_cara = _create_caregiver(
             first_name=cara.first_name,
@@ -390,7 +390,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='cara@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=999,  # TODO
+            legacy_id=3,
         )
         user_john = _create_caregiver(
             first_name=john.first_name,
@@ -399,7 +399,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='john@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=8,
+            legacy_id=4,
         )
         user_richard = _create_caregiver(
             first_name=richard.first_name,
@@ -408,7 +408,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='richard@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=998,  # TODO
+            legacy_id=5,
         )
         user_mike = _create_caregiver(
             first_name=mike.first_name,
@@ -417,7 +417,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='mike@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=997,  # TODO
+            legacy_id=6,
         )
         user_kathy = _create_caregiver(
             first_name=kathy.first_name,
@@ -426,7 +426,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='kathy@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=996,  # TODO
+            legacy_id=7,
         )
         user_valerie = _create_caregiver(
             first_name=valerie.first_name,
@@ -435,7 +435,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='valerie@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=995,  # TODO
+            legacy_id=8,
         )
         user_pete = _create_caregiver(
             first_name=pete.first_name,
@@ -444,7 +444,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='pete@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=994,  # TODO
+            legacy_id=9,
         )
         user_martin = _create_caregiver(
             first_name=martin.first_name,
@@ -453,7 +453,7 @@ def _create_test_data(institution_option: InstitutionOption) -> None:  # noqa: P
             email='martin@opalmedapps.ca',
             language='en',
             phone_number='',
-            legacy_id=993,  # TODO
+            legacy_id=10,
         )
 
     # get relationship types

--- a/opal/legacy/tests/test_utils.py
+++ b/opal/legacy/tests/test_utils.py
@@ -243,6 +243,16 @@ def test_create_user() -> None:
     assert legacy_user.username == 'test-username'
 
 
+def test_create_user_legacy_id() -> None:
+    """The legacy user is created successfully with the desired legacy ID."""
+    legacy_user = legacy_utils.create_user(models.LegacyUserType.CAREGIVER, 123, 'test-username', 321)
+
+    legacy_user.full_clean()
+    legacy_user.refresh_from_db()
+
+    assert legacy_user.usersernum == 321
+
+
 def test_update_legacy_user_type() -> None:
     """Ensure that a legacy user's type can be updated."""
     legacy_user = factories.LegacyUserFactory.create(usertype=models.LegacyUserType.CAREGIVER)
@@ -303,6 +313,20 @@ def test_create_caregiver_user_caregiver() -> None:
     assert legacy_user.usertype == models.LegacyUserType.CAREGIVER
     assert legacy_user.usertypesernum == legacy_patient.patientsernum
     assert legacy_user.username == 'test-username'
+
+
+def test_create_caregiver_user_caregiver_legacy_id() -> None:
+    """The caregiver user is created with the desired legacy ID."""
+    relationship = patient_factories.Relationship.create(
+        patient__legacy_id=None,
+        caregiver__user__first_name='John',
+        caregiver__user__last_name='Wayne',
+        caregiver__legacy_id=123,
+    )
+
+    legacy_user = legacy_utils.create_caregiver_user(relationship, 'test-username', 'fr', 'marge@opalmedapps.ca')
+
+    assert legacy_user.usersernum == 123
 
 
 def test_change_caregiver_user_to_patient() -> None:

--- a/opal/legacy/utils.py
+++ b/opal/legacy/utils.py
@@ -274,7 +274,9 @@ def initialize_new_patient(
     return legacy_patient
 
 
-def create_user(user_type: LegacyUserType, user_type_id: int, username: str) -> LegacyUsers:
+def create_user(
+    user_type: LegacyUserType, user_type_id: int, username: str, legacy_id: int | None = None
+) -> LegacyUsers:
     """
     Create a user with the given properties.
 
@@ -282,11 +284,13 @@ def create_user(user_type: LegacyUserType, user_type_id: int, username: str) -> 
         user_type: the type of the user
         user_type_id: the legacy ID of the type of the user (e.g., the patient ID for a patient)
         username: the username of the user
+        legacy_id: the desired legacy ID of the patient, if a specific ID is required
 
     Returns:
         the created user instance
     """
     user = LegacyUsers(
+        usersernum=legacy_id,
         usertype=user_type,
         usertypesernum=user_type_id,
         username=username,
@@ -340,6 +344,7 @@ def create_caregiver_user(
     user_patient_legacy_id: int = relationship.patient.legacy_id  # type: ignore[assignment]
     user_type = LegacyUserType.PATIENT
     language = LegacyLanguage(language.upper())
+    legacy_id = relationship.caregiver.legacy_id
 
     if relationship.type.is_self:
         legacy_patient = LegacyPatient.objects.get(patientsernum=user_patient_legacy_id)
@@ -360,7 +365,7 @@ def create_caregiver_user(
         user_patient_legacy_id = dummy_patient.patientsernum
         user_type = LegacyUserType.CAREGIVER
 
-    return create_user(user_type, user_patient_legacy_id, username)
+    return create_user(user_type, user_patient_legacy_id, username, legacy_id)
 
 
 def change_caregiver_user_to_patient(caregiver_legacy_id: int, patient: Patient) -> None:


### PR DESCRIPTION
Ensure that test users get the correct legacy ID assigned when they are created via the `insert_test_data` management command.