### PR TITLE
chore: enable Renovate lockfile maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,11 @@
   //
   // https://docs.renovatebot.com/configuration-options/#rebasewhen
   "rebaseWhen": "conflicted",
+  // Keep uv lockfile updated regularly
+  // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
+  "lockfileMaintenance": {
+    "enabled": true,
+  },
   "packageRules": [
     // Change commit type to build for Docker-related updates
     {


### PR DESCRIPTION
Keep transitive dependencies in `uv.lock` updated.

https://docs.renovatebot.com/configuration-options/#lockfilemaintenance