### PR TITLE
ci: mount DB service container data to tmpfs volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
           MARIADB_PASSWORD: ${{ env.DB_PASSWORD }}
         options: |
           --mount type=tmpfs,destination=/var/lib/mysql
+          --innodb-flush-method=nosync
 
     steps:
       - name: Install Git


### PR DESCRIPTION
Trying out the proposed techniques from: https://pythonspeed.com/articles/faster-db-tests/