### PR TITLE
chore: fix typo in Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,7 @@
   "rebaseWhen": "conflicted",
   // Keep uv lockfile updated regularly
   // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
-  "lockfileMaintenance": {
+  "lockFileMaintenance": {
     "enabled": true,
   },
   "packageRules": [


### PR DESCRIPTION
Created an invalid config in #1768.

Fixes #1770 