### PR TITLE
fix: replace python-jose with joserfc

### DIFF
--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -1113,6 +1113,12 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+## joserfc
+
+- Homepage: https://jose.authlib.org/en/
+- Repository: https://github.com/authlib/joserfc
+- License: `BSD-3-Clause`
+
 ## kaleido
 
 - Homepage: https://plotly.com/python/static-image-export/
@@ -1673,36 +1679,6 @@ THE SOFTWARE.
 The MIT License (MIT)
 
 Copyright (c) 2017 to present Pydantic Services Inc. and individual contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-## python-jose
-
-- Homepage: https://python-jose.readthedocs.org/en/latest/
-- Repository: https://github.com/mpdavis/python-jose
-- License: `MIT`
-
-```text
-The MIT License (MIT)
-
-Copyright (c) 2015 Michael Davis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/opal/patients/api/tests/test_api_views.py
+++ b/opal/patients/api/tests/test_api_views.py
@@ -1149,6 +1149,7 @@ class TestPatientSummaryView:
 
         saved_data = Path(saved_file).read_text(encoding='utf-8')
 
+        # base64 URL decode to have 32 bytes of data
         raw_key = util.urlsafe_b64decode(encryption_key.encode('utf-8'))
         key = jwk.OctKey.import_key(raw_key)
 

--- a/opal/patients/api/tests/test_api_views.py
+++ b/opal/patients/api/tests/test_api_views.py
@@ -21,7 +21,7 @@ from django.utils import timezone
 import pytest
 import requests
 from authlib.integrations.requests_client import OAuth2Session
-from jose import jwe, utils
+from joserfc import jwe, jwk, util
 from pytest_django.asserts import assertContains, assertJSONEqual, assertRaisesMessage
 from pytest_mock import MockerFixture
 from rest_framework import status
@@ -1149,12 +1149,13 @@ class TestPatientSummaryView:
 
         saved_data = Path(saved_file).read_text(encoding='utf-8')
 
-        # base64 URL decode to have 32 bytes of data
-        key_decoded = utils.base64url_decode(encryption_key.encode('utf-8'))
+        raw_key = util.urlsafe_b64decode(encryption_key.encode('utf-8'))
+        key = jwk.OctKey.import_key(raw_key)
 
-        decrypted_data = jwe.decrypt(saved_data, key_decoded)
+        decrypted_data = jwe.decrypt_compact(saved_data, key)
 
-        assert data == decrypted_data.decode('utf-8')
+        assert decrypted_data.plaintext is not None
+        assert data == decrypted_data.plaintext.decode('utf-8')
 
     def test_summary_saved_with_patientreporteddata(
         self,

--- a/opal/services/fhir/tests/test_utils.py
+++ b/opal/services/fhir/tests/test_utils.py
@@ -12,7 +12,7 @@ import requests
 from authlib.integrations.requests_client import OAuth2Session
 from authlib.oauth2 import OAuth2Error
 from fhir.resources.R4B.bundle import Bundle
-from jose import jwe, utils
+from joserfc import jwe, jwk, util
 from pytest_mock import MockerFixture
 
 from opal.services.fhir.fhir import FHIRConnector
@@ -37,26 +37,32 @@ FHIR_SETTINGS = FHIRConnectionSettings(
 def test_jwe_sh_link_encrypt() -> None:
     """The encrypted data can be decrypted correctly."""
     data = 'secret data'
-    key, encrypted = jwe_sh_link_encrypt(data)
+    raw_key, encrypted = jwe_sh_link_encrypt(data)
 
     # Key should be exactly 43 characters (32 bytes of randomness -> base64 encoded without padding)
-    assert len(key) == 43, f'Key length is {len(key)}, expected 43 characters'
+    assert len(raw_key) == 43, f'Key length is {len(raw_key)}, expected 43 characters'
 
-    key_decoded = utils.base64url_decode(key.encode('utf-8'))
-    decrypted = jwe.decrypt(encrypted, key_decoded).decode('utf-8')
+    key_decoded = util.urlsafe_b64decode(raw_key.encode('utf-8'))
+    key = jwk.OctKey.import_key(key_decoded)
 
-    assert decrypted == data
+    decrypted = jwe.decrypt_compact(encrypted, key).plaintext
+
+    assert decrypted is not None
+    assert decrypted.decode('utf-8') == data
 
 
 def test_jwe_sh_link_encrypt_empty() -> None:
     """Empty encrypted data can be encrypted and decrypted correctly."""
     data = ''
-    key, encrypted = jwe_sh_link_encrypt(data)
+    raw_key, encrypted = jwe_sh_link_encrypt(data)
 
-    key_decoded = utils.base64url_decode(key.encode('utf-8'))
-    decrypted = jwe.decrypt(encrypted, key_decoded).decode('utf-8')
+    key_decoded = util.urlsafe_b64decode(raw_key.encode('utf-8'))
+    key = jwk.OctKey.import_key(key_decoded)
 
-    assert decrypted == data
+    decrypted = jwe.decrypt_compact(encrypted, key).plaintext
+
+    assert decrypted is not None
+    assert decrypted.decode('utf-8') == data
 
 
 def test_jwe_sh_link_encrypt_different() -> None:

--- a/opal/services/fhir/utils.py
+++ b/opal/services/fhir/utils.py
@@ -15,7 +15,7 @@ import structlog
 from authlib.oauth2 import OAuth2Error
 from fhir.resources.R4B.observation import Observation
 from fhir.resources.R4B.reference import Reference
-from jose import jwe, utils
+from joserfc import jwe, jwk
 from pydantic_core import PydanticCustomError, ValidationError
 from requests import RequestException
 
@@ -59,14 +59,13 @@ def jwe_sh_link_encrypt(data: str) -> tuple[str, bytes]:
     Returns:
         a tuple of the encryption key (as a URL-safe base64 string) and the encrypted data (as bytes)
     """
-    # generate key with 32 bytes of randomness
-    key = secrets.token_urlsafe(32)
-    # base64 URL decode to have 32 bytes of data
-    key_decoded = utils.base64url_decode(key.encode('utf-8'))
+    # generate key with 256 bits
+    raw_key = secrets.token_urlsafe(24)
+    key = jwk.import_key(raw_key)
 
-    encrypted = jwe.encrypt(data, key_decoded, algorithm='dir', encryption='A256GCM', cty='application/fhir+json')
+    encrypted = jwe.encrypt_compact({'alg': 'dir', 'enc': 'A256GCM'}, data, key)
 
-    return (key, encrypted)
+    return (raw_key, encrypted.encode('utf-8'))
 
 
 def retrieve_patient_summary(

--- a/opal/services/fhir/utils.py
+++ b/opal/services/fhir/utils.py
@@ -5,7 +5,6 @@
 """Utility functions for FHIR functionality, including building patient summaries and JWE encryption."""
 
 import logging
-import secrets
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -15,7 +14,7 @@ import structlog
 from authlib.oauth2 import OAuth2Error
 from fhir.resources.R4B.observation import Observation
 from fhir.resources.R4B.reference import Reference
-from joserfc import jwe, jwk
+from joserfc import jwe, jwk, util
 from pydantic_core import PydanticCustomError, ValidationError
 from requests import RequestException
 
@@ -59,11 +58,11 @@ def jwe_sh_link_encrypt(data: str) -> tuple[str, bytes]:
     Returns:
         a tuple of the encryption key (as a URL-safe base64 string) and the encrypted data (as bytes)
     """
-    # generate key with 256 bits
-    raw_key = secrets.token_urlsafe(24)
-    key = jwk.import_key(raw_key)
+    key = jwk.OctKey.generate_key(256)
+    raw_key = util.urlsafe_b64encode(key.raw_value).decode('utf-8')
+    header = {'alg': 'dir', 'enc': 'A256GCM', 'cty': 'application/fhir+json'}
 
-    encrypted = jwe.encrypt_compact({'alg': 'dir', 'enc': 'A256GCM'}, data, key)
+    encrypted = jwe.encrypt_compact(header, data, key)
 
     return (raw_key, encrypted.encode('utf-8'))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "fpdf2==2.8.7",
     "hl7apy==1.3.5",
     # required for image export in plotly
+    "joserfc==1.6.4",
     "kaleido==1.2.0",
     "mysqlclient==2.2.8",
     "openpyxl==3.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "pillow==12.2.0",
     "plotly==6.7.0",
     "pydantic==2.12.5",
-    "python-jose[cryptography]==3.5.0",
     "qrcode==8.2",
     "requests==2.33.1",
     "slippers==0.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-20T17:56:53.121697Z"
+exclude-newer = "2026-04-20T18:18:46.924864Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -47,7 +47,6 @@ dependencies = [
     { name = "pillow" },
     { name = "plotly" },
     { name = "pydantic" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "qrcode" },
     { name = "requests" },
     { name = "slippers" },
@@ -131,7 +130,6 @@ requires-dist = [
     { name = "pillow", specifier = "==12.2.0" },
     { name = "plotly", specifier = "==6.7.0" },
     { name = "pydantic", specifier = "==2.12.5" },
-    { name = "python-jose", extras = ["cryptography"], specifier = "==3.5.0" },
     { name = "qrcode", specifier = "==8.2" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "slippers", specifier = "==0.7.0" },
@@ -851,18 +849,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/0e/a4f50d83e76cbe797eda88fc0083c8ca970cfa362b5586359ef06ec6f70a/drf_spectacular-0.29.0.tar.gz", hash = "sha256:0a069339ea390ce7f14a75e8b5af4a0860a46e833fd4af027411a3e94fc1a0cc", size = 241722, upload-time = "2025-11-02T03:40:26.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d9/502c56fc3ca960075d00956283f1c44e8cafe433dada03f9ed2821f3073b/drf_spectacular-0.29.0-py3-none-any.whl", hash = "sha256:d1ee7c9535d89848affb4427347f7c4a22c5d22530b8842ef133d7b72e19b41a", size = 105433, upload-time = "2025-11-02T03:40:24.823Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -1718,15 +1704,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1944,25 +1921,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "pytkdocs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2076,18 +2034,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
     { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-04-20T17:56:53.121697Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -39,6 +39,7 @@ dependencies = [
     { name = "fhir-resources" },
     { name = "fpdf2" },
     { name = "hl7apy" },
+    { name = "joserfc" },
     { name = "kaleido" },
     { name = "mysqlclient" },
     { name = "openpyxl" },
@@ -122,6 +123,7 @@ requires-dist = [
     { name = "fpdf2", specifier = "==2.8.7" },
     { name = "gunicorn", marker = "extra == 'prod'", specifier = "==25.3.0" },
     { name = "hl7apy", specifier = "==1.3.5" },
+    { name = "joserfc", specifier = "==1.6.4" },
     { name = "kaleido", specifier = "==1.2.0" },
     { name = "mysqlclient", specifier = "==2.2.8" },
     { name = "openpyxl", specifier = "==3.1.5" },
@@ -1071,6 +1073,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`python-jose` seems unmaintained and includes a dependency that has a vulnerability (with no fix).

Upgrading to `authlib` v1.7.0 in #2042 showed that there is `joserfc` which is already used by `authlib`. So we might as well use it for generating the key and encrypt the IPS as well.